### PR TITLE
Add GitHub codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# these owners will be requested for review when someone
+# opens a pull request.
+* @GitRepsCommunity/staff


### PR DESCRIPTION
resolves #16

* Adds a `CODEOWNERS` file to the root of the project
* Sets the Staff team as the global owner