### PR TITLE
resolves #11: Install dotenv for environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore environment variables.
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem "bootsnap", require: false
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,10 @@ GEM
     debug (1.8.0)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     erubi (1.12.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -217,6 +221,7 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
+  dotenv-rails
   importmap-rails
   jbuilder
   pg

--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ You may need to run ```brew tap homebrew/core``` if brew does not recognize post
 
 To start services run:
 ```
-docker compose up --build
+docker compose up
 ```
 
-If the database doesn't exist yet run:
+If new dependencies have been added (Gemfile updated) include the `--build` flag.
 ```
-docker compose run web rake db:create
+docker compose up --build
 ```
 
 Any commands to be executed in the web service (rails app)
@@ -72,23 +72,16 @@ can be done with the following:
 docker compose run web <cmd>
 ```
 
----------------------------------------------------------------------------
+If the database doesn't exist yet run:
+```
+docker compose run web rake db:create
+```
 
-This README still needs to document whatever steps are necessary to get the
-application up and running.
 
-Things left to cover:
+## Environment Variables
+This project uses dotenv for storing local environment variables.
+Create a new `.env` file at the root of the project and add the following variables:
 
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+```
+POSTGRES_PASSWORD=password
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: postgres:14.1-alpine
     restart: always
     environment:
-      - POSTGRES_PASSWORD=password
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     volumes:
       - ./tmp/db:/var/lib/postgresql/data
   web:


### PR DESCRIPTION
resolves #11

## Summary
Install and configure dotenv for managing local environment variables.

## Reviewer Guidance
After this gets merged, you'll need to create a `.env` file locally since it is git ignored. Make sure to add the `POSTGRES_PASSWORD` variable.