### PR TITLE
platform 26: UI for user sign up view

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  layout 'authentication', only: [:new, :create]
+
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,64 +1,66 @@
 # frozen_string_literal: true
 
-class Users::RegistrationsController < Devise::RegistrationsController
-  layout 'authentication', only: [:new, :create]
+module Users
+  class RegistrationsController < Devise::RegistrationsController
+    layout 'authentication', only: %i[new create]
 
-  # before_action :configure_sign_up_params, only: [:create]
-  # before_action :configure_account_update_params, only: [:update]
+    # before_action :configure_sign_up_params, only: [:create]
+    # before_action :configure_account_update_params, only: [:update]
 
-  # GET /resource/sign_up
-  # def new
-  #   super
-  # end
+    # GET /resource/sign_up
+    # def new
+    #   super
+    # end
 
-  # POST /resource
-  # def create
-  #   super
-  # end
+    # POST /resource
+    # def create
+    #   super
+    # end
 
-  # GET /resource/edit
-  # def edit
-  #   super
-  # end
+    # GET /resource/edit
+    # def edit
+    #   super
+    # end
 
-  # PUT /resource
-  # def update
-  #   super
-  # end
+    # PUT /resource
+    # def update
+    #   super
+    # end
 
-  # DELETE /resource
-  # def destroy
-  #   super
-  # end
+    # DELETE /resource
+    # def destroy
+    #   super
+    # end
 
-  # GET /resource/cancel
-  # Forces the session data which is usually expired after sign
-  # in to be expired now. This is useful if the user wants to
-  # cancel oauth signing in/up in the middle of the process,
-  # removing all OAuth session data.
-  # def cancel
-  #   super
-  # end
+    # GET /resource/cancel
+    # Forces the session data which is usually expired after sign
+    # in to be expired now. This is useful if the user wants to
+    # cancel oauth signing in/up in the middle of the process,
+    # removing all OAuth session data.
+    # def cancel
+    #   super
+    # end
 
-  # protected
+    # protected
 
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
+    # If you have extra params to permit, append them to the sanitizer.
+    # def configure_sign_up_params
+    #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+    # end
 
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_account_update_params
-  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-  # end
+    # If you have extra params to permit, append them to the sanitizer.
+    # def configure_account_update_params
+    #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+    # end
 
-  # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+    # The path used after sign up.
+    # def after_sign_up_path_for(resource)
+    #   super(resource)
+    # end
 
-  # The path used after sign up for inactive accounts.
-  # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+    # The path used after sign up for inactive accounts.
+    # def after_inactive_sign_up_path_for(resource)
+    #   super(resource)
+    # end
+  end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,29 +1,40 @@
-<h2>Sign up</h2>
-
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <div class="w-96 flex flex-col">
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+    <div class="mt-6">
+      <%= f.email_field :email,
+        autofocus: true,
+        autocomplete: "email",
+        placeholder: "Email",
+        class: "w-full rounded-md border-0 outline-0"
+      %>
+    </div>
 
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
+    <div class="mt-6">
+      <%= f.password_field :password,
+        autocomplete: "new-password",
+        placeholder: "Password",
+        class: "w-full rounded-md border-0 outline-0"
+      %>
+    </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
+    <div class="mt-6">
+      <%= f.password_field :password_confirmation,
+        autocomplete: "new-password",
+        placeholder: "Confirm Password",
+        class: "w-full rounded-md border-0 outline-0"
+      %>
+    </div>
 
-  <div class="actions">
-    <%= f.submit "Sign up" %>
+    <div class="mt-6">
+      <%= f.submit "Sign up",
+        class: "flex w-full justify-center rounded-md bg-blue-600 px-3 py-3 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+      %>
+    </div>
   </div>
 <% end %>
 
-<%= render "devise/shared/links" %>
+<div class="flex flex-row text-gray-400 mt-24">
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,11 +1,11 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
+  <div class="w-full p-5 rounded-md border border-1 border-rose-700 bg-rose-100 text-rose-700 text-sm" id="error_explanation" data-turbo-cache="false">
+    <div>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
-    </h2>
+    </div>
     <ul>
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -4,8 +4,8 @@
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <span class="mr-2">Not a member yet?</span>
-  <%= link_to "Sign up", new_registration_path(resource_name), class: "text-blue-600" %><br />
+  <span class="mr-2">Not a member?</span>
+  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,9 +1,11 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <span class="mr-2">Already a member yet?</span>
+  <%= link_to "Log in", new_session_path(resource_name), class: "text-blue-600" %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <span class="mr-2">Not a member yet?</span>
+  <%= link_to "Sign up", new_registration_path(resource_name), class: "text-blue-600" %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,10 +1,10 @@
 <%- if controller_name != 'sessions' %>
-  <span class="mr-2">Already a member yet?</span>
+  <span class="mr-2">Already a member?</span>
   <%= link_to "Log in", new_session_path(resource_name), class: "text-blue-600" %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <span class="mr-2">Not a member?</span>
+  <span class="mr-2">Not a member yet?</span>
   <%= link_to "Sign up", new_registration_path(resource_name) %><br />
 <% end %>
 

--- a/app/views/layouts/authentication.erb
+++ b/app/views/layouts/authentication.erb
@@ -14,9 +14,11 @@
   <body>
     <%= render "shared/nav" %>
     <main class="container mx-auto mt-28 px-5 flex">
-      <p class="notice"><%= notice %></p>
-      <p class="alert"><%= alert %></p>
-      <%= yield %>
+      <div class='w-full flex flex-col items-center justify-center'>
+        <p class="notice"><%= notice %></p>
+        <p class="alert"><%= alert %></p>
+        <%= yield %>
+      </div>
     </main>
   </body>
 </html>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -1,0 +1,15 @@
+<nav class='h-16 w-full flex items-center justify-around'>
+    <div class='w-24 px-4'>
+        <%= link_to "Home", "/" %>
+    </div>
+    <div class='flex justify-center w-96 text-2xl'>
+        GitReps
+    </div>
+    <div class='w-24 px-4'>
+        <%- if controller_name != 'sessions' %>
+            <%= link_to "Log in", new_session_path(resource_name) %>
+        <%- elsif devise_mapping.registerable? && controller_name != 'registrations' %>
+            <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+        <% end %>
+    </div>
+</nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: 'users/registrations'
+  }
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")


### PR DESCRIPTION
## Summary
Closes #26 

- Adds UI styles to the user sign up page. See the Figma designs [here](https://www.figma.com/file/v7o5QQemNK3pe8faIfrJAl/User-Profile?type=design&node-id=37-188&mode=design&t=aWS8Qhe5KaVBwzLG-0).
- Uses Tailwind css classes
- Adds a shared navigation partial
- Generates the devise registrations controller to use the new `authentication.html.erb` layout
- Basic styles for error messages

## Reviewer Guidance
> Describe anything you would like specific feedback on.

## Demo
> Add any relevant screenshots or videos to demo the changes.

![Screenshot_8_17_23__2_07_PM](https://github.com/GitRepsCommunity/platform/assets/137091252/d03e2553-d4a4-4c8f-aa6e-e1e60b4bb0c7)

![Screenshot_8_17_23__2_08_PM-2](https://github.com/GitRepsCommunity/platform/assets/137091252/18f7d09b-de9d-47d1-b92e-666e334397e2)

![Screenshot_8_17_23__2_08_PM](https://github.com/GitRepsCommunity/platform/assets/137091252/9f8bc981-5d1d-4015-93be-842183d41a0b)
