### PR TITLE
Define profile and user model relationships

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Profile < ApplicationRecord
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,9 @@ class User < ApplicationRecord
          :validatable,
          :omniauthable, omniauth_providers: %i[github]
 
+  has_many :profiles, dependent: :destroy
+  has_many :api_requests, dependent: :destroy, class_name: 'GithubExplorer::ApiRequest'
+
   def self.from_omniauth(auth)
     find_or_create_by(provider: auth.provider, uid: auth.uid) do |user|
       user.password = Devise.friendly_token[0, 20]

--- a/test/models/github_explorer/api_request_test.rb
+++ b/test/models/github_explorer/api_request_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module GithubExplorer
+  class ApiRequestTest < ActiveSupport::TestCase
+    test 'belongs_to user' do
+      api_request = users(:one).api_requests.create
+
+      assert_nothing_raised do
+        api_request.user
+      end
+    end
+  end
+end

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -4,7 +4,8 @@ require 'test_helper'
 
 class ProfileTest < ActiveSupport::TestCase
   test 'belongs_to user' do
-    profile = Profile.find(1)
-    assert_equal profile.user_id, profile.user.id
+    assert_nothing_raised do
+      profiles(:one).user
+    end
   end
 end

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -3,7 +3,8 @@
 require 'test_helper'
 
 class ProfileTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'belongs_to user' do
+    profile = Profile.find(1)
+    assert_equal profile.user_id, profile.user.id
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -4,6 +4,19 @@ require 'test_helper'
 require 'json'
 
 class UserTest < ActiveSupport::TestCase
+  test 'has_many profiles' do
+    user = User.find(1)
+    assert_equal 1, user.profiles.count
+
+    user.profiles.create
+    assert_equal 2, user.profiles.count
+
+    # dependent: :destroy
+    profile_ids = user.profiles.ids
+    user.destroy
+    assert_equal 0, Profile.where(id: profile_ids).count
+  end
+
   test 'from_omniauth' do
     raw_auth_response = JSON.parse(File.read('test/fixtures/omniauth_response.json'))
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -5,13 +5,21 @@ require 'json'
 
 class UserTest < ActiveSupport::TestCase
   test 'has_many profiles' do
-    user = User.find(1)
+    assert_nothing_raised do
+      users(:one).profiles
+    end
+  end
+
+  test 'has_many api_requests' do
+    assert_nothing_raised do
+      users(:one).api_requests
+    end
+  end
+
+  test 'profiles dependent destroy' do
+    user = users(:one)
     assert_equal 1, user.profiles.count
 
-    user.profiles.create
-    assert_equal 2, user.profiles.count
-
-    # dependent: :destroy
     profile_ids = user.profiles.ids
     user.destroy
     assert_equal 0, Profile.where(id: profile_ids).count


### PR DESCRIPTION
## Summary
By defining the `has_many` and `belongs_to` attributes on the data models, we can reference relationships using dot notation, like so:

```ruby
user.profiles
```
and
```ruby
profile.user
```